### PR TITLE
Add new throttle type

### DIFF
--- a/GCDThrottle/GCDThrottle.h
+++ b/GCDThrottle/GCDThrottle.h
@@ -13,12 +13,25 @@
 
 typedef void (^GCDThrottleBlock) ();
 
+
+/** Throttle type */
+typedef NS_ENUM(NSInteger, GCDThrottleType) {
+    GCDThrottleTypeDelayAndInvoke,/**< Throttle will wait for [threshold] seconds to invoke the block, when new block comes, it cancels the previous block and restart waiting for [threshold] seconds to invoke the new one. */
+    GCDThrottleTypeInvokeAndIgnore,/**< Throttle invokes the block at once and then wait for [threshold] seconds before it can invoke another new block, all block invocations during waiting time will be ignored. */
+};
+
+
+#pragma mark -
 @interface GCDThrottle : NSObject
 
 void dispatch_throttle(NSTimeInterval threshold, GCDThrottleBlock block);
 void dispatch_throttle_on_queue(NSTimeInterval threshold, dispatch_queue_t queue, GCDThrottleBlock block);
+void dispatch_throttle_by_type(NSTimeInterval threshold, GCDThrottleType type, GCDThrottleBlock block);
+void dispatch_throttle_by_type_on_queue(NSTimeInterval threshold, GCDThrottleType type, dispatch_queue_t queue, GCDThrottleBlock block);
 
 + (void)throttle:(NSTimeInterval)threshold block:(GCDThrottleBlock)block;
 + (void)throttle:(NSTimeInterval)threshold queue:(dispatch_queue_t)queue block:(GCDThrottleBlock)block;
++ (void)throttle:(NSTimeInterval)threshold type:(GCDThrottleType)type block:(GCDThrottleBlock)block;
++ (void)throttle:(NSTimeInterval)threshold type:(GCDThrottleType)type queue:(dispatch_queue_t)queue block:(GCDThrottleBlock)block;
 
 @end

--- a/GCDThrottle/GCDThrottle.m
+++ b/GCDThrottle/GCDThrottle.m
@@ -6,12 +6,50 @@
 //  Copyright © 2016年 cyan. All rights reserved.
 //
 
+
 #import "GCDThrottle.h"
+
 
 #define ThreadCallStackSymbol       [NSThread callStackSymbols][1]
 
+
+#pragma mark -
 @implementation GCDThrottle
 
+#pragma mark public: general
+void dispatch_throttle(NSTimeInterval threshold, GCDThrottleBlock block) {
+    [GCDThrottle _throttle:threshold type:GCDThrottleTypeDelayAndInvoke queue:THROTTLE_MAIN_QUEUE key:ThreadCallStackSymbol block:block];
+}
+
+void dispatch_throttle_on_queue(NSTimeInterval threshold, dispatch_queue_t queue, GCDThrottleBlock block) {
+    [GCDThrottle _throttle:threshold type:GCDThrottleTypeDelayAndInvoke queue:queue key:ThreadCallStackSymbol block:block];
+}
+
+void dispatch_throttle_by_type(NSTimeInterval threshold, GCDThrottleType type, GCDThrottleBlock block) {
+    [GCDThrottle _throttle:threshold type:type queue:THROTTLE_MAIN_QUEUE key:ThreadCallStackSymbol block:block];
+}
+
+void dispatch_throttle_by_type_on_queue(NSTimeInterval threshold, GCDThrottleType type, dispatch_queue_t queue, GCDThrottleBlock block) {
+    [GCDThrottle _throttle:threshold type:type queue:queue key:ThreadCallStackSymbol block:block];
+}
+
++ (void)throttle:(NSTimeInterval)threshold block:(GCDThrottleBlock)block {
+    [self _throttle:threshold type:GCDThrottleTypeDelayAndInvoke queue:THROTTLE_MAIN_QUEUE key:ThreadCallStackSymbol block:block];
+}
+
++ (void)throttle:(NSTimeInterval)threshold queue:(dispatch_queue_t)queue block:(GCDThrottleBlock)block {
+    [self _throttle:threshold type:GCDThrottleTypeDelayAndInvoke queue:queue key:ThreadCallStackSymbol block:block];
+}
+
++ (void)throttle:(NSTimeInterval)threshold type:(GCDThrottleType)type block:(GCDThrottleBlock)block {
+    [self _throttle:threshold type:type queue:THROTTLE_MAIN_QUEUE key:ThreadCallStackSymbol block:block];
+}
+
++ (void)throttle:(NSTimeInterval)threshold type:(GCDThrottleType)type queue:(dispatch_queue_t)queue block:(GCDThrottleBlock)block {
+    [self _throttle:threshold type:type queue:queue key:ThreadCallStackSymbol block:block];
+}
+
+#pragma mark private: general
 + (NSMutableDictionary *)scheduledSources {
     static NSMutableDictionary *_sources = nil;
     static dispatch_once_t token;
@@ -21,46 +59,43 @@
     return _sources;
 }
 
-void dispatch_throttle(NSTimeInterval threshold, GCDThrottleBlock block) {
-    _dispatch_throttle_on_queue(threshold, THROTTLE_MAIN_QUEUE, ThreadCallStackSymbol, block);
-}
-
-void dispatch_throttle_on_queue(NSTimeInterval threshold, dispatch_queue_t queue, GCDThrottleBlock block) {
-    _dispatch_throttle_on_queue(threshold, queue, ThreadCallStackSymbol, block);
-}
-
-void _dispatch_throttle_on_queue(NSTimeInterval threshold, dispatch_queue_t queue, NSString *key, GCDThrottleBlock block) {
-    [GCDThrottle _throttle:threshold queue:queue key:key block:block];
-}
-
-+ (void)throttle:(NSTimeInterval)threshold block:(GCDThrottleBlock)block {
-    [self _throttle:threshold queue:THROTTLE_MAIN_QUEUE key:ThreadCallStackSymbol block:block];
-}
-
-+ (void)throttle:(NSTimeInterval)threshold queue:(dispatch_queue_t)queue block:(GCDThrottleBlock)block {
-    [self _throttle:threshold queue:queue key:ThreadCallStackSymbol block:block];
-}
-
-+ (void)_throttle:(NSTimeInterval)threshold queue:(dispatch_queue_t)queue key:(NSString *)key block:(GCDThrottleBlock)block {
-    
-    NSMutableDictionary *scheduledSources = self.scheduledSources;
-    
-    dispatch_source_t source = scheduledSources[key];
-    
-    if (source) {
-        dispatch_source_cancel(source);
-    }
-    
-    source = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, queue);
-    dispatch_source_set_timer(source, dispatch_time(DISPATCH_TIME_NOW, threshold * NSEC_PER_SEC), DISPATCH_TIME_FOREVER, 0);
-    dispatch_source_set_event_handler(source, ^{
++ (void)_throttle:(NSTimeInterval)threshold type:(GCDThrottleType)type queue:(dispatch_queue_t)queue key:(NSString *)key block:(GCDThrottleBlock)block {
+    if (type == GCDThrottleTypeDelayAndInvoke) {
+        NSMutableDictionary *scheduledSources = self.scheduledSources;
+        
+        dispatch_source_t source = scheduledSources[key];
+        
+        if (source) {
+            dispatch_source_cancel(source);
+        }
+        
+        source = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, queue);
+        dispatch_source_set_timer(source, dispatch_time(DISPATCH_TIME_NOW, threshold * NSEC_PER_SEC), DISPATCH_TIME_FOREVER, 0);
+        dispatch_source_set_event_handler(source, ^{
+            block();
+            dispatch_source_cancel(source);
+            [scheduledSources removeObjectForKey:key];
+        });
+        dispatch_resume(source);
+        
+        scheduledSources[key] = source;
+    } else if (type == GCDThrottleTypeInvokeAndIgnore) {
+        NSMutableDictionary *scheduledSources = self.scheduledSources;
+        
+        dispatch_source_t source = scheduledSources[key];
+        if (source) { return; }
+        
         block();
-        dispatch_source_cancel(source);
-        [scheduledSources removeObjectForKey:key];
-    });
-    dispatch_resume(source);
-    
-    scheduledSources[key] = source;
+        source = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, queue);
+        dispatch_source_set_timer(source, dispatch_time(DISPATCH_TIME_NOW, threshold * NSEC_PER_SEC), DISPATCH_TIME_FOREVER, 0);
+        dispatch_source_set_event_handler(source, ^{
+            dispatch_source_cancel(source);
+            [scheduledSources removeObjectForKey:key];
+        });
+        dispatch_resume(source);
+        
+        scheduledSources[key] = source;
+    }
 }
 
 @end

--- a/GCDThrottle/ViewController.m
+++ b/GCDThrottle/ViewController.m
@@ -13,21 +13,9 @@
 
 - (IBAction)textFieldValueChanged:(UITextField *)sender {
     
-    dispatch_throttle(0.3, ^{
-        NSLog(@"search: %@", sender.text);
+    dispatch_throttle_by_type(1, GCDThrottleTypeInvokeAndIgnore, ^{
+        NSLog(@"%@", sender.text);
     });
-    
-    dispatch_throttle_on_queue(0.3, THROTTLE_GLOBAL_QUEUE, ^{
-        NSLog(@"search: %@", sender.text);
-    });
-    
-    [GCDThrottle throttle:0.3 block:^{
-        NSLog(@"search: %@", sender.text);
-    }];
-    
-    [GCDThrottle throttle:0.3 queue:THROTTLE_GLOBAL_QUEUE block:^{
-        NSLog(@"search: %@", sender.text);
-    }];
 }
 
 @end


### PR DESCRIPTION
增加了新的Throttle类型。
原来的throttle模式是等待一段时间以后激活block，如果在等待时间之内有新的调用过来，则原来等待的那个block会被取消，重新计时。这种模式在搜索的时候很好用。
增加的这种模式是先激活block，然后进入一段时间的不应期，在不应期里面，新的调用会被忽略，直到不应期过完。这种模式对“以某个特定的时间间隔进行操作”，比如说消息列表的更新，比较好用。